### PR TITLE
Use where instead of filter

### DIFF
--- a/backbone.rel.js
+++ b/backbone.rel.js
@@ -109,11 +109,8 @@
    * @return {Array<Model>|Null}
    */
   RelHandler.prototype.handleHasMany = function () {
-    var options = getOptions(this.self, 'hasMany', this.key);
-
-    function filter(el) {
-      return el.get(options.id) === this.id;
-    }
+    var options = getOptions(this.self, 'hasMany', this.key)
+      , where = {};
 
     if (!options) {
       return null;
@@ -127,7 +124,16 @@
       throw Error('No collection was given');
     }
 
-    return options.collection.filter(_.bind(options.filter || filter, this.self));
+    if (options.filter) {
+      return options.collection.filter(_.bind(options.filter, this.self));
+    }
+
+    if (options.id) {
+      where[options.id] = this.self.id;
+      return options.collection.where(where);
+    }
+
+    throw Error('Unknown options');
   };
 
   /**

--- a/package.json
+++ b/package.json
@@ -2,10 +2,14 @@
   "name": "backbone.rel",
   "description": "Lightweight relationship assistant for your backbone applications",
   "version": "0.2.4",
-  "author": "Pau ramon <masylum@gmail.com>",
+  "author": "Pau Ramon <masylum@gmail.com>",
   "contributors": ["Maxim Colls <collsmaxim@gmail.com>", "Saimon Moore <saimonmoore@gmail.com>"],
   "keywords": ["backbone", "relations", "ender", "teambox"],
   "repository": {"type": "git", "url": "git://github.com/masylum/Backbone.Rel.git"},
-  "devDependencies": {"backbone": "0.5.3", "underscore": "*", "mocha": "*"},
-  "main": "./backbone.rel.js"
+  "main": "./backbone.rel.js",
+  "devDependencies": {
+    "backbone": "^1.0.0",
+    "underscore": "^1.5.0",
+    "mocha": "*"
+  }
 }


### PR DESCRIPTION
Several libraries optimise que Collection.where method to use indexes (https://github.com/mllocs/backbone.turbo-where and https://github.com/adamrneary/backbone-index) dramatically improving the performance on big collection sets. With this PR, Backbone.Rel will use the where method if you setup a simple hasMany relation. 

I also updated the dev dependencies, the where method was introduced some versions after Backbone 0.5.3 (the previous dev dependency version).